### PR TITLE
Transaction receipt preview & overview

### DIFF
--- a/src/api/Api.js
+++ b/src/api/Api.js
@@ -93,5 +93,8 @@ export default {
   },
   transactionMonthsPath() {
     return process.env.REACT_APP_API_HOST + "transactions/months_list";
+  },
+  destroyReceiptPath(Id) {
+    return process.env.REACT_APP_API_HOST + `transactions/${Id}/receipts`;
   }
 };

--- a/src/dest/main.css
+++ b/src/dest/main.css
@@ -158,6 +158,9 @@
 .margin-left-5 {
   margin-left: 5px; }
 
+.margin-top-35 {
+  margin-top: 35px; }
+
 .activityBox {
   position: relative;
   margin-top: 15px; }

--- a/src/dest/main.css
+++ b/src/dest/main.css
@@ -161,6 +161,9 @@
 .margin-top-35 {
   margin-top: 35px; }
 
+.max-width-100 {
+  max-width: 100%; }
+
 .activityBox {
   position: relative;
   margin-top: 15px; }

--- a/src/dest/main.css
+++ b/src/dest/main.css
@@ -158,9 +158,6 @@
 .margin-left-5 {
   margin-left: 5px; }
 
-.margin-top-35 {
-  margin-top: 35px; }
-
 .max-width-100 {
   max-width: 100%; }
 

--- a/src/forms/transactions/charges/NewChargeForm.js
+++ b/src/forms/transactions/charges/NewChargeForm.js
@@ -242,7 +242,7 @@ class NewChargeForm extends Component {
             <Tags handleChangeTags={this.handleChangeTags} props={this.props} />
             <FileUploaderComponent
               handleChangeFile={this.handleChangeFile}
-              props={this.props}
+              file={charge.file}
             />
           </Form>
         </Modal.Body>

--- a/src/forms/transactions/charges/UpdateChargeForm.js
+++ b/src/forms/transactions/charges/UpdateChargeForm.js
@@ -24,6 +24,7 @@ import updateTransaction from "../../../actions/transactions/updateTransaction";
 import successAlert from "../../../actions/successAlert";
 import { ErrorModalAlert } from "../ErrorModalAlert";
 import { chargeValidator } from "./chargeValidator";
+import { FileUploaderComponent } from "../fileUploaderComponent";
 
 class UpdateChargeForm extends Component {
   static defaultProps = {
@@ -60,7 +61,9 @@ class UpdateChargeForm extends Component {
         date: new Date(transaction.attributes.date).toISOString().slice(0, 10),
         amount: transaction.attributes.from_amount,
         tag_ids: tagOptions,
-        note: transaction.attributes.note
+        note: transaction.attributes.note,
+        file: null,
+        uploadedFile: transaction.attributes.receipt
       }
     };
   };
@@ -148,6 +151,14 @@ class UpdateChargeForm extends Component {
       charge: {
         ...this.state.charge,
         note: event.target.value
+      }
+    });
+
+  handleChangeFile = event =>
+    this.setState({
+      charge: {
+        ...this.state.charge,
+        file: event.target.files[0]
       }
     });
 
@@ -249,6 +260,11 @@ class UpdateChargeForm extends Component {
               handleChangeTags={this.handleChangeTags}
               props={this.props}
               charge={charge}
+            />
+            <FileUploaderComponent
+              handleChangeFile={this.handleChangeFile}
+              file={charge.file}
+              uploadedFile={charge.uploadedFile}
             />
           </Form>
         </Modal.Body>

--- a/src/forms/transactions/fileUploaderComponent.js
+++ b/src/forms/transactions/fileUploaderComponent.js
@@ -1,14 +1,25 @@
-import { Col, ControlLabel, FormGroup } from "react-bootstrap";
+import { Col, ControlLabel, FormGroup, Thumbnail } from "react-bootstrap";
 import React from "react";
 
-export const FileUploaderComponent = ({ handleChangeFile }) => {
+export const FileUploaderComponent = ({ handleChangeFile, file }) => {
+  let img = null;
+  if (file) {
+    const filePreview = URL.createObjectURL(file);
+    img = (
+      <Thumbnail href="#" src={filePreview} thumbnail alt="Receipt preview" />
+    );
+  }
+
   return (
     <FormGroup>
       <Col componentClass={ControlLabel} sm={2}>
         Receipt:
       </Col>
       <Col sm={10}>
-        <input type="file" onChange={handleChangeFile} />
+        <div className="col-md-6">
+          <input type="file" onChange={handleChangeFile} />
+        </div>
+        <div className="col-md-6">{img}</div>
       </Col>
     </FormGroup>
   );

--- a/src/forms/transactions/fileUploaderComponent.js
+++ b/src/forms/transactions/fileUploaderComponent.js
@@ -1,13 +1,19 @@
 import { Col, ControlLabel, FormGroup, Thumbnail } from "react-bootstrap";
 import React from "react";
 
-export const FileUploaderComponent = ({ handleChangeFile, file }) => {
+export const FileUploaderComponent = ({
+  handleChangeFile,
+  file,
+  uploadedFile
+}) => {
   let img = null;
-  if (file) {
+
+  if (file && file instanceof File) {
     const filePreview = URL.createObjectURL(file);
-    img = (
-      <Thumbnail href="#" src={filePreview} thumbnail alt="Receipt preview" />
-    );
+    img = <Thumbnail href="#" src={filePreview} alt="Receipt preview" />;
+  } else if (uploadedFile && typeof uploadedFile === "object") {
+    const filePreview = uploadedFile.thumbnail;
+    img = <Thumbnail href="#" src={filePreview} alt="Receipt preview" />;
   }
 
   return (

--- a/src/forms/transactions/profits/NewProfitForm.js
+++ b/src/forms/transactions/profits/NewProfitForm.js
@@ -242,7 +242,7 @@ class NewProfitForm extends Component {
             <Tags handleChangeTags={this.handleChangeTags} props={this.props} />
             <FileUploaderComponent
               handleChangeFile={this.handleChangeFile}
-              props={this.props}
+              file={profit.file}
             />
           </Form>
         </Modal.Body>

--- a/src/forms/transactions/profits/UpdateProfitForm.js
+++ b/src/forms/transactions/profits/UpdateProfitForm.js
@@ -1,4 +1,4 @@
-import React, {Component, Fragment} from "react";
+import React, { Component, Fragment } from "react";
 import { Button, Form, Modal } from "react-bootstrap";
 import {
   ToAccount,
@@ -24,6 +24,7 @@ import patchTransactionRequest from "../../../services/requests/patchTransaction
 import successAlert from "../../../actions/successAlert";
 import { ErrorModalAlert } from "../ErrorModalAlert";
 import { profitValidator } from "./profitValidator";
+import { FileUploaderComponent } from "../fileUploaderComponent";
 
 class UpdateProfitForm extends Component {
   static defaultProps = {
@@ -60,7 +61,9 @@ class UpdateProfitForm extends Component {
         date: new Date(transaction.attributes.date).toISOString().slice(0, 10),
         amount: transaction.attributes.from_amount,
         tag_ids: tagOptions,
-        note: transaction.attributes.note
+        note: transaction.attributes.note,
+        file: null,
+        uploadedFile: transaction.attributes.receipt
       },
       showErrorAlert: false,
       errorMessages: {
@@ -182,6 +185,14 @@ class UpdateProfitForm extends Component {
       }
     });
 
+  handleChangeFile = event =>
+    this.setState({
+      profit: {
+        ...this.state.profit,
+        file: event.target.files[0]
+      }
+    });
+
   handleSubmit = event => {
     event.preventDefault();
 
@@ -255,6 +266,11 @@ class UpdateProfitForm extends Component {
               handleChangeTags={this.handleChangeTags}
               props={this.props}
               profit={profit}
+            />
+            <FileUploaderComponent
+              handleChangeFile={this.handleChangeFile}
+              file={profit.file}
+              uploadedFile={profit.uploadedFile}
             />
           </Form>
         </Modal.Body>

--- a/src/forms/transactions/transactionFormHelpers.js
+++ b/src/forms/transactions/transactionFormHelpers.js
@@ -118,4 +118,4 @@ export const errorPointersAndDetails = messages => {
 const setTags = tag_ids =>
   tag_ids ? tag_ids.map(tag => Number(tag.value)) : [];
 
-const setReceipt = file => file ? { receipt: file } : null;
+const setReceipt = file => (file ? { receipt: file } : null);

--- a/src/forms/transactions/transfers/NewTransferForm.js
+++ b/src/forms/transactions/transfers/NewTransferForm.js
@@ -288,7 +288,7 @@ class NewTransferForm extends Component {
             <Tags handleChangeTags={this.handleChangeTags} props={this.props} />
             <FileUploaderComponent
               handleChangeFile={this.handleChangeFile}
-              props={this.props}
+              file={transfer.file}
             />
           </Form>
         </Modal.Body>

--- a/src/forms/transactions/transfers/UpdateTransferForm.js
+++ b/src/forms/transactions/transfers/UpdateTransferForm.js
@@ -25,6 +25,7 @@ import {
   getOptionsForTag,
   transferAttributes
 } from "../transactionFormHelpers";
+import { FileUploaderComponent } from "../fileUploaderComponent";
 
 class UpdateTransferForm extends Component {
   static defaultProps = {
@@ -62,7 +63,9 @@ class UpdateTransferForm extends Component {
         date: new Date(transaction.attributes.date).toISOString().slice(0, 10),
         amount: transaction.attributes.from_amount,
         tag_ids: tagOptions,
-        note: transaction.attributes.note
+        note: transaction.attributes.note,
+        file: null,
+        uploadedFile: transaction.attributes.receipt
       },
       rate: {
         from: transaction.attributes.from_amount,
@@ -195,6 +198,14 @@ class UpdateTransferForm extends Component {
     );
   };
 
+  handleChangeFile = event =>
+    this.setState({
+      transfer: {
+        ...this.state.transfer,
+        file: event.target.files[0]
+      }
+    });
+
   formValidation = () =>
     this.setState(
       transferValidator(this.state.transfer, this.state.validationState)
@@ -305,6 +316,11 @@ class UpdateTransferForm extends Component {
               handleChangeTags={this.handleChangeTags}
               props={this.props}
               transfer={transfer}
+            />
+            <FileUploaderComponent
+              handleChangeFile={this.handleChangeFile}
+              file={transfer.file}
+              uploadedFile={transfer.uploadedFile}
             />
           </Form>
         </Modal.Body>

--- a/src/pages/mainPage/main/activities/transactions/DestroyTransactionModal.js
+++ b/src/pages/mainPage/main/activities/transactions/DestroyTransactionModal.js
@@ -63,11 +63,14 @@ class DestroyTransactionModal extends Component {
   }
 }
 
-export default connect(null, dispatch => ({
-  deleteTransaction: transaction => {
-    dispatch(deleteTransaction(transaction));
-  },
-  updateAccount: account => {
-    dispatch(updateAccount(account));
-  }
-}))(DestroyTransactionModal);
+export default connect(
+  null,
+  dispatch => ({
+    deleteTransaction: transaction => {
+      dispatch(deleteTransaction(transaction));
+    },
+    updateAccount: account => {
+      dispatch(updateAccount(account));
+    }
+  })
+)(DestroyTransactionModal);

--- a/src/pages/mainPage/main/activities/transactions/ReceiptImage.js
+++ b/src/pages/mainPage/main/activities/transactions/ReceiptImage.js
@@ -32,7 +32,7 @@ export default class ReceiptImage extends Component {
             <Modal.Header closeButton />
             <Modal.Body>
               <img
-                className="center-block"
+                className="center-block max-width-100"
                 src={receipt.original}
                 alt={imageName}
               />

--- a/src/pages/mainPage/main/activities/transactions/ReceiptImage.js
+++ b/src/pages/mainPage/main/activities/transactions/ReceiptImage.js
@@ -1,0 +1,47 @@
+import React, { Component, Fragment } from "react";
+import { Modal } from "react-bootstrap";
+
+export default class ReceiptImage extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      showReceiptModal: false
+    };
+  }
+
+  handleClose = () => this.setState({ showReceiptModal: false });
+  handleShow = () => this.setState({ showReceiptModal: true });
+
+  render() {
+    const { transaction } = this.props;
+
+    if (transaction && transaction.attributes.receipt) {
+      const receipt = transaction.attributes.receipt;
+
+      const imageName = receipt.filename;
+
+      return (
+        <Fragment>
+          <img
+            src={receipt.thumbnail}
+            className="img-thumbnail"
+            alt={imageName}
+            onClick={this.handleShow}
+          />
+          <Modal show={this.state.showReceiptModal} onHide={this.handleClose}>
+            <Modal.Header closeButton />
+            <Modal.Body>
+              <img
+                className="center-block"
+                src={receipt.original}
+                alt={imageName}
+              />
+            </Modal.Body>
+          </Modal>
+        </Fragment>
+      );
+    } else {
+      return null;
+    }
+  }
+}

--- a/src/pages/mainPage/main/activities/transactions/ReceiptImage.js
+++ b/src/pages/mainPage/main/activities/transactions/ReceiptImage.js
@@ -1,7 +1,12 @@
 import React, { Component, Fragment } from "react";
 import { Modal } from "react-bootstrap";
+import destroyTransactionReceipt from "../../../../../services/requests/destroyTransactionReceipt";
+import Api from "../../../../../api/Api";
+import { connect } from "react-redux";
+import updateTransaction from "../../../../../actions/transactions/updateTransaction";
+import successAlert from "../../../../../actions/successAlert";
 
-export default class ReceiptImage extends Component {
+class ReceiptImage extends Component {
   constructor(props) {
     super(props);
     this.state = {
@@ -11,6 +16,19 @@ export default class ReceiptImage extends Component {
 
   handleClose = () => this.setState({ showReceiptModal: false });
   handleShow = () => this.setState({ showReceiptModal: true });
+
+  handleReceiptDestroy = transaction => {
+    destroyTransactionReceipt(Api.destroyReceiptPath(transaction.id)).then(
+      responce => {
+        if (responce.status === 200) {
+          this.props.updateTransaction(responce.data);
+        } else {
+          console.log("error", responce);
+        }
+      }
+    );
+    return false;
+  };
 
   render() {
     const { transaction } = this.props;
@@ -22,9 +40,15 @@ export default class ReceiptImage extends Component {
 
       return (
         <Fragment>
+          <div
+            className="transaction-control cursor-pointer control-destroy"
+            onClick={() => this.handleReceiptDestroy(transaction)}
+          >
+            destroy
+          </div>
           <img
             src={receipt.thumbnail}
-            className="img-thumbnail"
+            className="img-thumbnail cursor-pointer"
             alt={imageName}
             onClick={this.handleShow}
           />
@@ -45,3 +69,13 @@ export default class ReceiptImage extends Component {
     }
   }
 }
+
+export default connect(
+  null,
+  dispatch => ({
+    updateTransaction: transaction => {
+      dispatch(updateTransaction(transaction.data));
+      dispatch(successAlert(true, "Receipt successfully destroyed"));
+    }
+  })
+)(ReceiptImage);

--- a/src/pages/mainPage/main/activities/transactions/TransactionItem.js
+++ b/src/pages/mainPage/main/activities/transactions/TransactionItem.js
@@ -4,6 +4,7 @@ import FontAwesomeIcon from "@fortawesome/react-fontawesome";
 import faPencilAlt from "@fortawesome/fontawesome-free-solid/faPencilAlt";
 import faTimes from "@fortawesome/fontawesome-free-solid/faTimes";
 import TagList from "./tags/TagList";
+import ReceiptImage from "./ReceiptImage";
 
 class TransactionItem extends Component {
   constructor(props) {
@@ -61,7 +62,10 @@ class TransactionItem extends Component {
 
   transactionItem = (transaction, fromName, toName) => (
     <div key={transaction.id} className="col-md-12">
-      <div className="col-md-6">
+      <div className="col-md-offset-1 col-md-2 margin-top-35">
+        <ReceiptImage transaction={transaction} />
+      </div>
+      <div className="col-md-4">
         <div
           className="col-md-5 col-md-offset-1 transaction-control control-edit cursor-pointer"
           onClick={this.handleUpdateTransaction}
@@ -86,7 +90,7 @@ class TransactionItem extends Component {
           <p>Note: {transaction.attributes.note}</p>
         </div>
       </div>
-      <div className="col-md-6">
+      <div className="col-md-4">
         <p>Tags:</p>
         <TagList transaction={transaction} />
       </div>

--- a/src/pages/mainPage/main/activities/transactions/TransactionItem.js
+++ b/src/pages/mainPage/main/activities/transactions/TransactionItem.js
@@ -62,7 +62,7 @@ class TransactionItem extends Component {
 
   transactionItem = (transaction, fromName, toName) => (
     <div key={transaction.id} className="col-md-12">
-      <div className="col-md-offset-1 col-md-2 margin-top-35">
+      <div className="col-md-offset-1 col-md-2">
         <ReceiptImage transaction={transaction} />
       </div>
       <div className="col-md-4">

--- a/src/services/requests/destroyTransactionReceipt.js
+++ b/src/services/requests/destroyTransactionReceipt.js
@@ -1,0 +1,17 @@
+import LSProvider from "../session/localStorageProvider";
+import errorParser from "../errors/errorParser";
+import axios from "axios";
+
+export default function destroyTransactionReceipt(url) {
+  let token = LSProvider.getToken();
+  return axios
+    .delete(url, {
+      headers: { Authorization: "Bearer " + token }
+    })
+    .then(response => {
+      return response;
+    })
+    .catch(error => {
+      return errorParser(error);
+    });
+}

--- a/src/services/utils/jsonToFormData.js
+++ b/src/services/utils/jsonToFormData.js
@@ -3,7 +3,8 @@ function buildFormData(formData, data, parentKey) {
     data &&
     typeof data === "object" &&
     !(data instanceof Date) &&
-    !(data instanceof File)
+    !(data instanceof File) &&
+    !(data instanceof Array)
   ) {
     Object.keys(data).forEach(key => {
       buildFormData(
@@ -12,6 +13,10 @@ function buildFormData(formData, data, parentKey) {
         parentKey ? `${parentKey}[${key}]` : key
       );
     });
+  } else if (data instanceof Array) {
+    for (var i = 0; i < data.length; i++) {
+      formData.append(`${parentKey}[]`, data[i]);
+    }
   } else {
     const value = data == null ? "" : data;
 

--- a/src/styles/_activities.scss
+++ b/src/styles/_activities.scss
@@ -117,6 +117,10 @@
   margin-left: 5px;
 }
 
+.margin-top-35 {
+  margin-top: 35px;
+}
+
 .activityBox {
   position: relative;
   margin-top: 15px;

--- a/src/styles/_activities.scss
+++ b/src/styles/_activities.scss
@@ -121,6 +121,10 @@
   margin-top: 35px;
 }
 
+.max-width-100 {
+  max-width: 100%;
+}
+
 .activityBox {
   position: relative;
   margin-top: 15px;

--- a/src/styles/_activities.scss
+++ b/src/styles/_activities.scss
@@ -117,10 +117,6 @@
   margin-left: 5px;
 }
 
-.margin-top-35 {
-  margin-top: 35px;
-}
-
 .max-width-100 {
   max-width: 100%;
 }
@@ -142,4 +138,3 @@
   top: 3.3em;
   right: 4em;
 }
-


### PR DESCRIPTION
Add Receipt preview for uploaded file:
<img width="620" alt="Screen Shot 2020-03-17 at 15 37 57" src="https://user-images.githubusercontent.com/15985355/76861513-62fdb080-6865-11ea-9dd8-d5b43a575679.png">

Add Receipt overview for already uploaded files:

<img width="992" alt="Screen Shot 2020-03-17 at 15 43 51" src="https://user-images.githubusercontent.com/15985355/76862027-24b4c100-6866-11ea-9d32-80d93782573a.png">

->

<img width="760" alt="Screen Shot 2020-03-17 at 15 49 58" src="https://user-images.githubusercontent.com/15985355/76862577-ff748280-6866-11ea-90f8-3688ca268c4d.png">

